### PR TITLE
Handle partial reload

### DIFF
--- a/src/panel.js
+++ b/src/panel.js
@@ -30,7 +30,7 @@ chrome.storage.sync.get({ defaultOpenDepth: 2 }, (items) => {
         return inertiaPage = nextPage;
     }
 
-    const renderJson = (jsonString, isPartial) => {
+    const renderJson = (jsonString, isPartial = false) => {
         const page = mergePage(JSON.parse(jsonString), isPartial);
         const value = JSON.stringify(page, null, '\t')
         editor.setValue(value)
@@ -80,13 +80,11 @@ chrome.storage.sync.get({ defaultOpenDepth: 2 }, (items) => {
                 }
                 return
             }
-            if (request.request.headers.find((header) => header.name === 'x-inertia') ||
-                request.response.headers.find((header) => header.name === 'X-Inertia')) {
-                if (request.request.headers.some((header) => header.name === 'x-inertia-partial-data')) {
-                    request.getContent((content) => renderJson(content, true))
-                } else {
-                    request.getContent((content) => renderJson(content))
-                }
+            if (request.response.headers.find((header) => header.name === 'X-Inertia')) {
+                const isPartial = request.request.headers.some(
+                    (header) => header.name.toLowerCase() === 'x-inertia-partial-data'
+                );
+                request.getContent((content) => renderJson(content, isPartial));
                 return
             }
         }

--- a/src/panel.js
+++ b/src/panel.js
@@ -21,7 +21,7 @@ chrome.storage.sync.get({ defaultOpenDepth: 2 }, (items) => {
 
     let inertiaPage = {};
     const mergePage = (nextPage, isPartial = false) => {
-        if (isPartial) {
+        if (isPartial && inertiaPage.component === nextPage.component) {
             return inertiaPage = {
                 ...nextPage,
                 props: { ...inertiaPage.props, ...nextPage.props },

--- a/src/panel.js
+++ b/src/panel.js
@@ -80,7 +80,7 @@ chrome.storage.sync.get({ defaultOpenDepth: 2 }, (items) => {
                 }
                 return
             }
-            if (request.response.headers.find((header) => header.name === 'X-Inertia')) {
+            if (request.response.headers.find((header) => header.name.toLowerCase() === 'x-inertia')) {
                 const isPartial = request.request.headers.some(
                     (header) => header.name.toLowerCase() === 'x-inertia-partial-data'
                 );

--- a/src/panel.js
+++ b/src/panel.js
@@ -85,7 +85,7 @@ chrome.storage.sync.get({ defaultOpenDepth: 2 }, (items) => {
                 if (request.request.headers.some((header) => header.name === 'x-inertia-partial-data')) {
                     request.getContent((content) => renderJson(content, true))
                 } else {
-                    request.getContent(renderJson)
+                    request.getContent((content) => renderJson(content))
                 }
                 return
             }


### PR DESCRIPTION
When sending [partial reload](https://inertiajs.com/shared-data#sharing-data) requests, props should be merged to keep current page initial state.

Inertia sends the header `x-inertia-partial-data` when using `router.reload({ only: [...] })`, so when it's present I merge the previous saved page to the new one.